### PR TITLE
Fix formatting for installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo dpkg -i nightmare_1.0.deb
 ```
 #### Install with dependencies (If you need):
 
-```bash
+```console []
 sudo apt install macchanger network-manager anonsurf ufw wget toilet
 ```
 #### Then launch:


### PR DESCRIPTION
### Details
`bash` syntax highlight to `console` for dependency installation